### PR TITLE
Adding a time skew to the beacon intervals

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -133,6 +133,8 @@ Run Merlin Agent as script: `go run cmd/merlinagent/main.go`
         Enable debug output
   -sleep duration
         Time for agent to sleep (default 10s)
+  -skew int
+        Variable time skew for agent to sleep
   -url string
         Full URL for agent to connect to (default "https://127.0.0.1:443")
   -v    Enable verbose output

--- a/cmd/merlinagent/main.go
+++ b/cmd/merlinagent/main.go
@@ -32,8 +32,8 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"golang.org/x/net/http2"
 	"github.com/satori/go.uuid"
+	"golang.org/x/net/http2"
 	
 	"github.com/ne0nd0g/merlin/pkg/agent"
 	"github.com/ne0nd0g/merlin/pkg/messages"

--- a/cmd/merlinagent/main.go
+++ b/cmd/merlinagent/main.go
@@ -68,15 +68,15 @@ const (
 
 func main() {
 
-	rand.Seed(time.Now().Unix())
-
 	flag.BoolVar(&verbose, "v", false, "Enable verbose output")
 	flag.BoolVar(&debug, "debug", false, "Enable debug output")
 	flag.StringVar(&url, "url", url, "Full URL for agent to connect to")
-	flag.Int64Var(&waitSkew, "skew", 3000, "varriable skew added to each agent sleep")
+	flag.Int64Var(&waitSkew, "skew", 3000, "Variable time skew for agent to sleep")
 	flag.DurationVar(&waitTime, "sleep", 30000*time.Millisecond, "Time for agent to sleep")
 	flag.Usage = usage
 	flag.Parse()
+
+	rand.Seed(time.Now().UTC().UnixNano())
 
 	if verbose {
 		color.Yellow("[-]Agent version: %s", version)

--- a/cmd/merlinagent/main.go
+++ b/cmd/merlinagent/main.go
@@ -33,10 +33,11 @@ import (
 
 	"github.com/fatih/color"
 	"golang.org/x/net/http2"
-
+	"github.com/satori/go.uuid"
+	
 	"github.com/ne0nd0g/merlin/pkg/agent"
 	"github.com/ne0nd0g/merlin/pkg/messages"
-	"github.com/satori/go.uuid"
+	
 )
 
 // GLOBAL VARIABLES

--- a/cmd/merlinserver/main.go
+++ b/cmd/merlinserver/main.go
@@ -38,7 +38,6 @@ import (
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
-	"github.com/satori/go.uuid"
 
 	// Merlin
 	"github.com/ne0nd0g/merlin/pkg"


### PR DESCRIPTION
First pull request to get comfortable with the code base. This simply adds a command line options for a time skew, such that beacon intervals aren't perfectly regular and adds to the difficulty to detect them using signal intel. More pull requests w/ features to come!