### PR TITLE
modifies makefile to set callback url at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ PASSWORD=merlin
 BUILD=$(shell git rev-parse HEAD)
 DIR=data/temp/v${VERSION}/${BUILD}
 BIN=data/bin/
-LDFLAGS=-ldflags "-s -w -X main.build=${BUILD} -X github.com/Ne0nd0g/merlin/pkg/agent.build=${BUILD}"
-WINAGENTLDFLAGS=-ldflags "-s -w -X main.build=${BUILD} -X github.com/Ne0nd0g/merlin/pkg/agent.build=${BUILD} -H=windowsgui"
+XBUILD=-X main.build=${BUILD} -X github.com/Ne0nd0g/merlin/pkg/agent.build=${BUILD}
+URL ?= https://127.0.0.1:443
+XURL=-X main.url=${URL}
+LDFLAGS=-ldflags "-s -w ${XBUILD} ${XURL}"
+WINAGENTLDFLAGS=-ldflags "-s -w ${XBUILD} ${XURL} -H=windowsgui"
 PACKAGE=7za a -p${PASSWORD} -mhe -mx=9
 F=README.MD LICENSE data/modules docs data/README.MD data/agents/README.MD data/db/ data/log/README.MD data/x509 data/src data/bin data/html
 F2=LICENSE
@@ -54,7 +57,7 @@ agent-windows:
 # Compile Agent - Windows x64 DLL
 agent-dll:
 	export GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1; \
-	go build -buildmode=c-archive -o ${DIR}/main.a cmd/merlinagentdll/main.go; \
+	go build ${LDFLAGS} -buildmode=c-archive -o ${DIR}/main.a cmd/merlinagentdll/main.go; \
 	cp data/bin/dll/merlin.c ${DIR}; \
 	x86_64-w64-mingw32-gcc -shared -pthread -o ${DIR}/merlin.dll ${DIR}/merlin.c ${DIR}/main.a -lwinmm -lntdll -lws2_32
 
@@ -86,6 +89,7 @@ agent-darwin:
 agent-javascript:
 	sed -i 's/var build = ".*"/var build = "${BUILD}"/' data/html/scripts/merlin.js
 	sed -i 's/var version = ".*"/var version = "${VERSION}"/' data/html/scripts/merlin.js
+	sed -i 's|var url = ".*"|var url = "${URL}"|' data/html/scripts/merlin.js
 
 # Make directory 'data' and then agents, db, log, x509; Copy src folder, README, and requirements
 package-server-windows:

--- a/cmd/merlinagent/main.go
+++ b/cmd/merlinagent/main.go
@@ -33,7 +33,7 @@ import (
 )
 
 // GLOBAL VARIABLES
-var url = "https://127.0.0.1:443/"
+var url = "https://127.0.0.1:443"
 var build = "nonRelease"
 
 func main() {

--- a/cmd/merlinagentdll/main.go
+++ b/cmd/merlinagentdll/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Ne0nd0g/merlin/pkg/agent"
 )
 
-var url = "https://127.0.0.1:443/"
+var url = "https://127.0.0.1:443"
 
 func main() {}
 

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.6.6 - 2019-01-19
+
+### Changed
+
+- [Pull 43](https://github.com/Ne1nd0g/merlin/pull/43) - Gives users the ability to dynamically
+assign the callback URL variable at compile time by setting the URL= var in the make command
+
 ## 0.6.5 - 2019-01-10
 
 ### Fixed


### PR DESCRIPTION
### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.MD) doc
- [x] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [x] PR is against the **dev branch** (left side)
- [x] Merlin compiles without errors
- [x] Passes linting checks and unit tests
- [x] Updated [CHANGELOG](../CHANGELOG.MD)
- [ ] Updated README documentation (if applicable)

### Change Type
- [x] Modification
- [ ] Addition
- [ ] Bugfix
- [ ] Removal
- [ ] Security

### Description

In order to generate an agent so that the `-url` flag is not necessary, one currently had to modify the source code. This PR modifies the Makefile so that the callback url can be modified at compile-time, eliminating the need to modify the source each time.

For example:
```sh
make windows #generate agents with the callback URLof https://localhost:443

#generate agents with the callback URL of https://site.com:443
URL=https://site.com:443 make windows 
# or
make windows URL=https://site.com:443 