### PR TITLE
fixes case-sensitive autocomplete on module menu

### DIFF
--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+#
+## 0.6.6 - 2019-01-20
+
+### Fixed
+- [Pull 44](https://github.com/Ne0nd0g/merlin/pull/44) Fixes case-sensitive autocompletion of `agent`
+  on the module menu
+
+
 
 ## 0.6.5 - 2019-01-10
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -34,9 +34,9 @@ import (
 	// 3rd Party
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
+	"github.com/mattn/go-shellwords"
 	"github.com/olekukonko/tablewriter"
 	"github.com/satori/go.uuid"
-	"github.com/mattn/go-shellwords"
 
 	// Merlin
 	"github.com/Ne0nd0g/merlin/pkg"
@@ -155,7 +155,7 @@ func Shell() {
 					shellModule.ShowInfo()
 				case "set":
 					if len(cmd) > 2 {
-						if cmd[1] == "agent" {
+						if cmd[1] == "Agent" {
 							s, err := shellModule.SetAgent(cmd[2])
 							if err != nil {
 								message("warn", err.Error())
@@ -221,10 +221,10 @@ func Shell() {
 					}
 				case "download":
 					if len(cmd) >= 2 {
-						arg := strings.Join(cmd[1:]," ")
+						arg := strings.Join(cmd[1:], " ")
 						argS, errS := shellwords.Parse(arg)
 						if errS != nil {
-							message("warn",fmt.Sprintf("There was an error parsing command line argments: %s\r\n%s", line, errS.Error()))
+							message("warn", fmt.Sprintf("There was an error parsing command line argments: %s\r\n%s", line, errS.Error()))
 							break
 						}
 						if len(argS) >= 1 {
@@ -427,15 +427,15 @@ func Shell() {
 					}
 				case "upload":
 					if len(cmd) >= 3 {
-						arg := strings.Join(cmd[1:]," ")
+						arg := strings.Join(cmd[1:], " ")
 						argS, errS := shellwords.Parse(arg)
 						if errS != nil {
-							message("warn",fmt.Sprintf("There was an error parsing command line argments: %s\r\n%s", line, errS.Error()))
+							message("warn", fmt.Sprintf("There was an error parsing command line argments: %s\r\n%s", line, errS.Error()))
 							break
 						}
 						if len(argS) >= 2 {
 							_, errF := os.Stat(argS[0])
-							if errF != nil{
+							if errF != nil {
 								message("warn", fmt.Sprintf("There was an error accessing the source upload file:\r\n%s", errF.Error()))
 								break
 							}
@@ -604,7 +604,7 @@ func getCompleter(completer string) *readline.PrefixCompleter {
 			readline.PcItem("info"),
 		),
 		readline.PcItem("set",
-			readline.PcItem("agent",
+			readline.PcItem("Agent",
 				readline.PcItem("all"),
 				readline.PcItemDynamic(agents.GetAgentList()),
 			),


### PR DESCRIPTION
  * lint pass

### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.MD) doc
- [x] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [x] PR is against the **dev branch** (left side)
- [x] Merlin compiles without errors
- [x] Passes linting checks and unit tests
- [x] Updated [CHANGELOG](../CHANGELOG.MD)
- [ ] Updated README documentation (if applicable)

### Change Type
- [x] Bugfix
- [ ] Addition
- [ ] Modification
- [ ] Removal
- [ ] Security

### Description

Auto-completion in the Module menu wasn't expanding `Agent` because of case-sensitivity. The GUI shows `Agent` but the completor function was expecting `a<tab>`. This PR brings the behavior back to normal, matching the way completion is done in the rest of the menus.

Also my editor's linter changed some things.