### PR TITLE
adds an `ls` command to agents

### DIFF
--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.6.9 - 2019-01-28
+
+### Added
+- Adds `ls` as a capability so as to stay off the commandline. More to come.
+
 ## 0.6.8 - 2019-01-26
 
 ### Added

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -714,8 +714,8 @@ func (a *Agent) statusCheckIn(host string, client *http.Client) {
 				}
 			}
 
-		case "FileIO":
-			var p messages.FileIO
+		case "NativeCmd":
+			var p messages.NativeCmd
 			json.Unmarshal(payload, &p)
 
 			switch p.Command {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -714,6 +714,48 @@ func (a *Agent) statusCheckIn(host string, client *http.Client) {
 				}
 			}
 
+		case "FileIO":
+			var p messages.FileIO
+			json.Unmarshal(payload, &p)
+
+			switch p.Command {
+			case "ls":
+				listing, err := a.list(p.Args)
+				var se string
+				if err != nil {
+					se = err.Error()
+				}
+
+				c := messages.CmdResults{
+					Job:    p.Job,
+					Stdout: listing,
+					Stderr: se,
+				}
+
+				k, err := json.Marshal(c)
+				if err != nil {
+					panic(err)
+				}
+
+				g := messages.Base{
+					Version: 1.0,
+					ID:      j.ID,
+					Type:    "CmdResults",
+					Payload: (*json.RawMessage)(&k),
+					Padding: core.RandStringBytesMaskImprSrc(a.PaddingMax),
+				}
+				b2 := new(bytes.Buffer)
+				json.NewEncoder(b2).Encode(g)
+				if a.Verbose {
+					message("note", fmt.Sprintf("Sending response to server: %s", listing))
+				}
+				resp2, _ := client.Post(host, "application/json; charset=utf-8", b2)
+				if resp2.StatusCode != 200 {
+					if a.Verbose {
+						message("warn", fmt.Sprintf("Message error from server. HTTP Status code: %d", resp2.StatusCode))
+					}
+				}
+			}
 		default:
 			if a.Verbose {
 				message("warn", fmt.Sprintf("Received unrecognized message type: %s", j.Type))
@@ -921,6 +963,20 @@ func (a *Agent) agentInfo(host string, client *http.Client) {
 		return
 	}
 	a.FailedCheckin = 0
+}
+
+func (a *Agent) list(path string) (string, error) {
+	files, err := ioutil.ReadDir(path)
+	details := ""
+
+	for _, f := range files {
+		perms := f.Mode().String()
+		size := strconv.FormatInt(f.Size(), 10)
+		modTime := f.ModTime().String()[0:19]
+		name := f.Name()
+		details = details + perms + "\t" + modTime + "\t" + size + "\t" + name + "\n"
+	}
+	return details, err
 }
 
 // TODO Make a generic function to send a JSON message; Keep basic so protocols can be switched (i.e. DNS)

--- a/pkg/agents/agents.go
+++ b/pkg/agents/agents.go
@@ -420,7 +420,6 @@ func GetMessageForJob(agentID uuid.UUID, job Job) (messages.Base, error) {
 		}
 
 		k := marshalMessage(p)
-		m.Type = "CmdPayload"
 		m.Payload = (*json.RawMessage)(&k)
 	case "shellcode":
 		m.Type = "Shellcode"
@@ -476,6 +475,22 @@ func GetMessageForJob(agentID uuid.UUID, job Job) (messages.Base, error) {
 		} else {
 			message("info", fmt.Sprintf("Agent %s was removed from the server", agentID.String()))
 		}
+
+	case "ls":
+		m.Type = "FileIO"
+		p := messages.FileIO{
+			Job:     job.ID,
+			Command: job.Args[0],
+		}
+
+		if len(job.Args) > 1 {
+			p.Args = job.Args[1]
+		} else {
+			p.Args = "./"
+		}
+
+		k := marshalMessage(p)
+		m.Payload = (*json.RawMessage)(&k)
 	case "maxretry":
 		m.Type = "AgentControl"
 		p := messages.AgentControl{

--- a/pkg/agents/agents.go
+++ b/pkg/agents/agents.go
@@ -477,8 +477,8 @@ func GetMessageForJob(agentID uuid.UUID, job Job) (messages.Base, error) {
 		}
 
 	case "ls":
-		m.Type = "FileIO"
-		p := messages.FileIO{
+		m.Type = "NativeCmd"
+		p := messages.NativeCmd{
 			Job:     job.ID,
 			Command: job.Args[0],
 		}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -379,6 +379,14 @@ func Shell() {
 								m, shellAgent, time.Now().UTC().Format(time.RFC3339)))
 						}
 					}
+				case "ls":
+					m, err := agents.AddJob(shellAgent, "ls", cmd)
+					if err != nil {
+						message("warn", err.Error())
+						break
+					}
+					message("note", fmt.Sprintf("Created job %s for agent %s at %s",
+						m, shellAgent, time.Now().UTC().Format(time.RFC3339)))
 				case "main":
 					menuSetMain()
 				case "quit":
@@ -651,6 +659,7 @@ func getCompleter(completer string) *readline.PrefixCompleter {
 		readline.PcItem("help"),
 		readline.PcItem("info"),
 		readline.PcItem("kill"),
+		readline.PcItem("ls"),
 		readline.PcItem("main"),
 		readline.PcItem("shell"),
 		readline.PcItem("set",
@@ -743,6 +752,7 @@ func menuHelpAgent() {
 		{"execute-shellcode", "Execute shellcode", "self, remote"},
 		{"info", "Display all information about the agent", ""},
 		{"kill", "Instruct the agent to die or quit", ""},
+		{"ls", "List the contents of the current working directory", ""},
 		{"main", "Return to the main menu", ""},
 		{"set", "Set the value for one of the agent's options", "maxretry, padding, skew, sleep"},
 		{"shell", "Execute a command on the agent", "shell ping -c 3 8.8.8.8"},

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -380,13 +380,21 @@ func Shell() {
 						}
 					}
 				case "ls":
-					m, err := agents.AddJob(shellAgent, "ls", cmd)
-					if err != nil {
-						message("warn", err.Error())
-						break
+					var m string
+					if len(cmd) > 1 {
+						arg := strings.Join(cmd[1:], " ")
+						joinedArgs := []string{cmd[0], arg}
+						m, err = agents.AddJob(shellAgent, cmd[0], joinedArgs)
+						if err != nil {
+							message("warn", err.Error())
+							break
+						}
+					} else {
+						m, err = agents.AddJob(shellAgent, cmd[0], cmd)
 					}
 					message("note", fmt.Sprintf("Created job %s for agent %s at %s",
 						m, shellAgent, time.Now().UTC().Format(time.RFC3339)))
+
 				case "main":
 					menuSetMain()
 				case "quit":

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -93,8 +93,8 @@ type Shellcode struct {
 	PID    uint32 `json:"pid,omitempty"` // Process ID for remote injection
 }
 
-// FileIO is a JSON payload to send filesystem-related commands to the agent (ps, cd, cat, ls)
-type FileIO struct {
+// NativeCmd is a JSON payload to send filesystem-related commands to the agent (ps, cd, cat, ls)
+type NativeCmd struct {
 	Job     string `json:"job"`
 	Command string `json:"command"`
 	Args    string `json:"args,omitempty"`

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -92,3 +92,10 @@ type Shellcode struct {
 	Job    string `json:"job"`
 	PID    uint32 `json:"pid,omitempty"` // Process ID for remote injection
 }
+
+// FileIO is a JSON payload to send filesystem-related commands to the agent (ps, cd, cat, ls)
+type FileIO struct {
+	Job     string `json:"job"`
+	Command string `json:"command"`
+	Args    string `json:"args,omitempty"`
+}


### PR DESCRIPTION
### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.MD) doc
- [x] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [x] PR is against the **dev branch** (left side)
- [x] Merlin compiles without errors
- [x] Passes linting checks and unit tests
- [x] Updated [CHANGELOG](../CHANGELOG.MD)
- [ ] Updated README documentation (if applicable)

### Change Type
- [x] Addition
- [ ] Bugfix
- [ ] Modification
- [ ] Removal
- [ ] Security

### Description

In order to stay off the commandline, some basic filesystem navigation and IO should be done by the agent in a way that doesn't rely on the native shell.

This initial PR adds an `ls` command. 

